### PR TITLE
Fix SCSS deprecation warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler', // or "modern"
+      },
+    },
+  },
 });


### PR DESCRIPTION
Address a deprecation warning related to SCSS by updating the configuration to use the modern compiler API.