### PR TITLE
Add address and input form to General Plan

### DIFF
--- a/src/components/children/Headings/GeneralPlan.tsx
+++ b/src/components/children/Headings/GeneralPlan.tsx
@@ -46,6 +46,19 @@ const GeneralPlan = () => {
         button under “Sign up to receive LASHP General Plan Amendment
         information.”
       </p>
+      <p className="font-medium pt-4">
+        To provide written input using the online input form,{' '}
+        <a
+          href="https://www.surveymonkey.com/r/lastatehistoricparkgpa"
+          target="_blank"
+          className="text-blue-500 underline font-bold"
+        >
+          click here
+        </a>
+        . You may also email State Parks at{' '}
+        <span className="font-bold">lastatehistoricparkgpa@parks.ca.gov</span>{' '}
+        or mail your feedback to:
+      </p>
       <div className="font-normal pt-4 mx-4">
         <div className="py-2">
           <p className="font-bold">

--- a/src/components/children/Headings/GeneralPlan.tsx
+++ b/src/components/children/Headings/GeneralPlan.tsx
@@ -46,6 +46,15 @@ const GeneralPlan = () => {
         button under “Sign up to receive LASHP General Plan Amendment
         information.”
       </p>
+      <div className="font-normal pt-4 mx-4">
+        <div className="py-2">
+          <p className="font-bold">
+            Strategic Planning and Recreation Services Division
+          </p>
+          <p>c/o LASHP GPA</p>
+          <p>PO Box 942896 Sacramento CA 94296-0001</p>
+        </div>
+      </div>
       <p className="font-medium pt-4">
         <span className="font-bold">
           This initial input period will be open until 11:59 pm Pacific Time on


### PR DESCRIPTION
Include an online input form link and mailing address for feedback in the General Plan section.